### PR TITLE
add const COMMON_BASE_URI to support define backend api domain

### DIFF
--- a/src/apis/loginApi.ts
+++ b/src/apis/loginApi.ts
@@ -1,4 +1,4 @@
-import { request } from "@/config/request"
+import { request, COMMON_BASE_URI } from "@/config/request"
 
 export interface LoginFrom {
       username: string;
@@ -9,7 +9,7 @@ export interface LoginFrom {
 
 export const LoginApi = (login: LoginFrom) => {
       return request({
-            url: login.is_ldap ? "/ldap" : "/login",
+            url: login.is_ldap ? `${COMMON_BASE_URI}/ldap` : `${COMMON_BASE_URI}/login`,
             method: "POST",
             data: login
       })
@@ -17,14 +17,14 @@ export const LoginApi = (login: LoginFrom) => {
 
 export const IsRegister = () => {
       return request({
-            url: "/fetch",
+            url: `${COMMON_BASE_URI}/fetch`,
             method: "GET",
       })
 }
 
 export const OidcStateApi = () => {
       return request({
-            url: "/oidc/state",
+            url: `${COMMON_BASE_URI}/oidc/state`,
             method: "GET"
       })
 } 

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,4 +1,4 @@
-import { request, COMMON_URI } from "@/config/request"
+import { request, COMMON_URI, COMMON_BASE_URI } from "@/config/request"
 import { commonPage } from "@/types"
 import { AxiosPromise } from "axios"
 
@@ -72,7 +72,7 @@ export class Request {
       }
       Register (register: RegisterForm, isManager: boolean): AxiosPromise {
             return request({
-                  url: isManager ? `${COMMON_URI}/manage/user?tp=add` : "/register",
+                  url: isManager ? `${COMMON_URI}/manage/user?tp=add` : `${COMMON_BASE_URI}/register`,
                   method: "POST",
                   data: register
             })

--- a/src/config/request.ts
+++ b/src/config/request.ts
@@ -15,7 +15,9 @@ const { t } = i18n.global
 
 const ACCESS_TOKEN = sessionStorage.getItem("jwt")
 
-const COMMON_URI = "/api/v2"
+const COMMON_BASE_URI = ""
+const COMMON_URI = `${COMMON_BASE_URI}/api/v2`
+
 
 const request: AxiosInstance = axios.create({
       timeout: 200000,
@@ -75,5 +77,5 @@ request.interceptors.response.use((response) => {
 const overrideHeaders = () => { request.defaults.headers.common['Authorization'] = 'Bearer ' + store.state.user.account.token }
 
 export {
-      request, COMMON_URI, overrideHeaders, Res
+      request, COMMON_URI, COMMON_BASE_URI, overrideHeaders, Res
 }


### PR DESCRIPTION
### 遭遇场景：

- 前端部署方案： aws环境， s3存放前端文件， cloudfront用作cdn暴露给公网，提升访问速度
- 后端yearning： 部署到k8s环境，只暴露到内网，只作为api的调用, 需要vpn后才可以访问

### 遇到问题：
当前COMMON_URI常量，只包含了/api/v2的api路径，当定义一个和主域名不一样的后端api域名的时候， 需要改多个地方。

### 解决办法
要做到前后端分离，必须改COMMON_URI, 覆盖不全的地方增加一个COMMON_BASE_URI的常量，用于定义login和register的api域名路径
