### PR TITLE
fix: Display DDLEnableForeignKey option in UI for foreign key in table

### DIFF
--- a/src/lang/en-us/rule/index.ts
+++ b/src/lang/en-us/rule/index.ts
@@ -7,6 +7,8 @@ export default {
     'Non-text,blob, JSON, TIMESTAMP fields must have default values',
   DDLCheckFloatDouble: 'Force the float/double type to be of type Decimal',
   DDLEnableAutoincrementInit: 'The increment column to start with 1',
+  DDLEnableForeignKey: 'Whether foreign keys are allowed in table creation',
+  DDLEnablePrimaryKey: 'Check if a primary key is required',
   DDLPrimaryKeyMust: 'Force the primary key name to be ID',
   DDLEnableAutoIncrement: 'Forces primary keys to increment columns',
   DDLEnableAutoincrementUnsigned:

--- a/src/lang/zh-cn/rule/index.ts
+++ b/src/lang/zh-cn/rule/index.ts
@@ -17,6 +17,7 @@ export default {
   DDLAllowPRINotInt: '允许主键类型为非int/bigint',
   DDLEnableNullIndexName: '允许索引名为空',
   DDLMultiToCommit: '允许单个工单提交多条DDL语句',
+  DDLEnableForeignKey: '是否允许在创建表时使用外键',
   DDLEnablePrimaryKey: '是否检查必须拥有主键',
 
   DDLAllowMultiAlter: '允许单个工单执行多条ALTER语句',

--- a/src/views/manager/rules/rules.ts
+++ b/src/views/manager/rules/rules.ts
@@ -47,6 +47,12 @@ const rule: Rule[] = [
     tp: 0,
   },
   {
+    name: 'DDLEnableForeignKey',
+    desc: t('DDLEnableForeignKey'),
+    type: 'DDL',
+    tp: 0,
+  },
+  {
     name: 'DDLEnablePrimaryKey',
     desc: t('DDLEnablePrimaryKey'),
     type: 'DDL',


### PR DESCRIPTION
This pull request addresses the issue raised in [#1172](https://github.com/cookieY/Yearning/issues/1172), where the API returns all global configurations, but the UI fails to render some of them, specifically the DDLEnableForeignKey option for foreign key creation.